### PR TITLE
fix(macos26): guard 4 install functions that crash on macOS 26+

### DIFF
--- a/Sources/SpliceKit.m
+++ b/Sources/SpliceKit.m
@@ -2756,7 +2756,12 @@ static id SpliceKit_toolbar_itemForItemIdentifier(id self, SEL _cmd, NSToolbar *
 // handful of swizzles and class lookups crash at `appDidLaunch` time.
 // Track which host we are running on so we can skip the offending
 // install functions until a proper fix lands upstream.
-// See GitHub issue #50 for the bisection details.
+//
+// Root crash: SpliceKit_getActiveTimelineModule +16 — TLKTimelineView
+// accessor changed shape in macOS 26.3 + FCP 12.2 build 447037.
+// Bisection in issue #50.
+//
+// See GitHub issue #50 for the full bisection details.
 static BOOL SpliceKit_isMacOS26OrLater(void) {
     static BOOL result = NO;
     static dispatch_once_t once;

--- a/Sources/SpliceKit.m
+++ b/Sources/SpliceKit.m
@@ -2752,6 +2752,21 @@ static id SpliceKit_toolbar_itemForItemIdentifier(id self, SEL _cmd, NSToolbar *
 // point — you'll get nil back from objc_getClass for anything in Flexo.framework.
 //
 
+// macOS 26 (Darwin 25) restructured several private FCP classes so a
+// handful of swizzles and class lookups crash at `appDidLaunch` time.
+// Track which host we are running on so we can skip the offending
+// install functions until a proper fix lands upstream.
+// See GitHub issue #50 for the bisection details.
+static BOOL SpliceKit_isMacOS26OrLater(void) {
+    static BOOL result = NO;
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{
+        NSOperatingSystemVersion v = [[NSProcessInfo processInfo] operatingSystemVersion];
+        result = (v.majorVersion >= 26);
+    });
+    return result;
+}
+
 static void SpliceKit_appDidLaunch(void) {
     SpliceKit_log(@"================================================");
     SpliceKit_log(@"App launched. Starting control server...");
@@ -2760,11 +2775,19 @@ static void SpliceKit_appDidLaunch(void) {
     // Run compatibility check now that all frameworks are loaded
     SpliceKit_checkCompatibility();
 
+    if (SpliceKit_isMacOS26OrLater()) {
+        SpliceKit_log(@"[compat] macOS 26+ detected — some features disabled (see issue #50)");
+    }
+
     // Install focused editor routing before commands and menus start querying
     // activeEditorContainer, so the secondary timeline can participate in the
     // normal responder path.
-    SpliceKit_installDualTimeline();
-    SpliceKit_installDualTimelineCrossWindowDrag();
+    if (!SpliceKit_isMacOS26OrLater()) {
+        SpliceKit_installDualTimeline();
+        SpliceKit_installDualTimelineCrossWindowDrag();
+    } else {
+        SpliceKit_log(@"[DualTimeline] Skipped on macOS 26+ (class restructure — issue #50)");
+    }
 
     // Count total loaded classes
     unsigned int classCount = 0;
@@ -2784,7 +2807,11 @@ static void SpliceKit_appDidLaunch(void) {
 
     // Install effect-drag-as-adjustment-clip swizzle (allows dragging effects
     // to empty timeline space to create adjustment clips)
-    SpliceKit_installEffectDragAsAdjustmentClip();
+    if (!SpliceKit_isMacOS26OrLater()) {
+        SpliceKit_installEffectDragAsAdjustmentClip();
+    } else {
+        SpliceKit_log(@"[EffectDrag] Skipped on macOS 26+ (block dispatch crash — issue #50)");
+    }
 
     // Install viewer pinch-to-zoom if previously enabled
     if (SpliceKit_isViewerPinchZoomEnabled()) {
@@ -2847,7 +2874,11 @@ static void SpliceKit_appDidLaunch(void) {
     SpliceKit_installDebugMenuBar();
 
     // Install right-click context menu for structure block color changes
-    SpliceKit_installStructureBlockContextMenu();
+    if (!SpliceKit_isMacOS26OrLater()) {
+        SpliceKit_installStructureBlockContextMenu();
+    } else {
+        SpliceKit_log(@"[Structure] Skipped on macOS 26+ (TLKTimelineView restructure — issue #50)");
+    }
 
     // Start the control server on a background thread
     dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
@@ -2855,10 +2886,14 @@ static void SpliceKit_appDidLaunch(void) {
     });
 
     // Initialize Lua scripting VM
-    SpliceKitLua_initialize();
-
-    // Load plugins from ~/Library/Application Support/SpliceKit/plugins/
-    SpliceKitPlugins_loadAll();
+    if (!SpliceKit_isMacOS26OrLater()) {
+        SpliceKitLua_initialize();
+        // Load plugins from ~/Library/Application Support/SpliceKit/plugins/
+        SpliceKitPlugins_loadAll();
+    } else {
+        SpliceKit_log(@"[Lua] VM init skipped on macOS 26+ (issue #50)");
+        SpliceKit_log(@"[Plugins] Load skipped on macOS 26+ (depends on Lua VM)");
+    }
 }
 
 #pragma mark - Crash Prevention & Startup Fixes


### PR DESCRIPTION
Closes #50 (or at least unblocks it).

## Summary

macOS 26 (Darwin 25) restructured several private FCP classes. Four install functions in `SpliceKit_appDidLaunch` crash with `SIGSEGV` on **macOS 26.3 + FCP 12.2 build 447037** because the classes they swizzle have moved or changed shape.

This PR guards each offending call behind a runtime `SpliceKit_isMacOS26OrLater()` check. On macOS 15 and earlier, behaviour is unchanged. On macOS 26+, the four problematic functions are skipped with a clear log message referencing #50.

## The four crash sites (bisected)

| # | Function | Crash signal |
|---|---|---|
| 1 | `SpliceKit_installDualTimeline` + `installDualTimelineCrossWindowDrag` | `appDidLaunch + 56`, very early (swizzles `PEAppController`, `PEEditorContainerModule`, `LKWindowModule`, etc.) |
| 2 | `SpliceKit_installStructureBlockContextMenu` | First statement, no log emitted (`TLKTimelineView` lookup) |
| 3 | `SpliceKit_installEffectDragAsAdjustmentClip` | `__installEffectDragSwizzlesNow_block_invoke + 80` → `getActiveTimelineModule + 16` (async dispatched block) |
| 4 | `SpliceKitLua_initialize` | Inside Lua VM init (plus `SpliceKitPlugins_loadAll` which depends on Lua) |

## Why these are related

The startup log has a telltale sign:

```
WARNING: Final_Cut_Pro.CloudContentCatalogRegistryManifest exists but -updateCatalogAndRegistry not found
WARNING: Final_Cut_Pro.CloudContentCatalog exists but -updateCatalogAndRegistry not found
```

The swizzle target from #23 no longer exists on this build. This is visible in the `system.version` response (once it reaches that point):

```json
"swizzles": {
  "CloudContentFeatureFlag.isEnabled": true,
  "CloudContentFirstLaunchHelper.setupAndPresent(completion:)": true,
  "CloudContentCatalog.updateCatalogAndRegistry": false
}
```

Same pattern affects the four functions above. They all reach for a class / selector / ivar that has moved.

## Features lost on macOS 26+ (all non-critical)

- Dual timeline floating window
- Effect drag as adjustment clip
- Structure block right-click context menu
- Lua scripting VM and plugin loading

## Features preserved on macOS 26+ (core of SpliceKit)

- **179 MCP tools** + JSON-RPC control server on `127.0.0.1:9876`
- Transcript editor with Parakeet
- Scene / beat detection, caption generation
- Effects, transitions, color, audio, markers, library management
- FCPXML paste swizzle, freeze-extend transitions
- Favorites context menu, debug preferences pane, mixer skim hooks
- Full ObjC runtime introspection tools

## Verification

Tested on: **macOS 26.3 (Darwin 25.3.0) + FCP 12.2 build 447037 + Apple Silicon M3**, Apple Development identity signing.

Before this patch:

```
!!! FATAL SIGNAL: SIGSEGV (signal 11) !!!
Stack trace:
  2   SpliceKit    SpliceKit_appDidLaunch + 56
  3   SpliceKit    __SpliceKit_init_block_invoke_2 + 68
  4   CoreFoundation __CFNOTIFICATIONCENTER_IS_CALLING_OUT_TO_AN_OBSERVER__ + 128
  ...
  9   AppKit       -[NSApplication _postDidFinishNotification] + 308
```

After this patch:

```
[compat] macOS 26+ detected — some features disabled (see issue #50)
[DualTimeline] Skipped on macOS 26+ (class restructure — issue #50)
[EffectDrag] Skipped on macOS 26+ (block dispatch crash — issue #50)
[Structure] Skipped on macOS 26+ (TLKTimelineView restructure — issue #50)
[Lua] VM init skipped on macOS 26+ (issue #50)
[Plugins] Load skipped on macOS 26+ (depends on Lua VM)
================================================
Control server listening on 127.0.0.1:9876
================================================
Startup timing: constructor->launch=3.84s, launch->server=0.20s, total=4.03s
```

```bash
$ echo '{"jsonrpc":"2.0","method":"system.version","id":1}' | nc 127.0.0.1 9876
{
    "jsonrpc": "2.0",
    "id": 1,
    "result": {
        "fcp_version": "12.2",
        "fcp_build": "447037",
        "macos_version": "26.3.0",
        "arch": "arm64",
        "splicekit_version": "2.6.0",
        "signing_team": "C37H2F9RBW",
        "pid": 4627,
        ...
    }
}
```

## What a proper long-term fix would look like

These functions should be reworked to guard each class lookup and selector with `class_respondsToSelector` / `class_getInstanceMethod != NULL` checks so they degrade gracefully across FCP versions instead of crashing. I would be happy to take a pass at any of the four if you point me at which one you want first.

## Related

- #50 (crash report + full bisection logs)
- #48 (patcher step 4 false positive — separate bug I had to work around during install)
- #49 (.mcp.json at framework root breaks codesign — separate bug)
- #23 (closed) — related CloudContent crash, fixed at a different layer for earlier macOS versions

Thanks for SpliceKit — it is already the most capable FCP automation surface I have tried.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent launch crashes on macOS 26+ by gating four install functions behind a runtime check. On macOS 26+, we skip the affected swizzles and Lua init with clear logs; earlier macOS behavior is unchanged.

- **Bug Fixes**
  - Added `SpliceKit_isMacOS26OrLater()` and gated installs to avoid SIGSEGV at `appDidLaunch`; documented root crash site (TLKTimelineView +16).
  - Skipped on 26+: dual timeline (incl. cross‑window drag), effect‑drag‑as‑adjustment, structure block context menu, Lua VM + plugin load.
  - Verified on macOS 26.3 + FCP 12.2: startup succeeds, control server runs, core features remain; logs reference #50.

<sup>Written for commit 89694a39851734d34fab3bef1f02607daf63e53a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

