### PR TITLE
Patcher: strip xattrs before sign + pre-flight launch guard

### DIFF
--- a/patcher/SpliceKit/Models/PatcherModel.swift
+++ b/patcher/SpliceKit/Models/PatcherModel.swift
@@ -510,6 +510,18 @@ class PatcherModel: ObservableObject {
         guard canLaunchFCP else { return }
 
         let binary = moddedApp + "/Contents/MacOS/Final Cut Pro"
+
+        // Pre-flight existence check. canLaunchFCP only inspects patcher state
+        // (not patching, not launching, not running) — it does not verify the
+        // modded bundle is still on disk. If the user deleted it or the patch
+        // never completed, NSWorkspace.openApplication surfaces this as a raw
+        // NSCocoaErrorDomain Code 4 ("file doesn't exist") in Sentry with no
+        // actionable message. Catch it early with a clear log line instead.
+        guard FileManager.default.fileExists(atPath: binary) else {
+            appendLog("Cannot launch: modded Final Cut Pro is missing at \(moddedApp). Run the patch again from the Welcome panel.")
+            syncModdedFCPRunningState()
+            return
+        }
         let launchTime = Date()
         let spliceKitLogURL = runtimeLogURL(named: "splicekit.log")
         let spliceKitLogDateBeforeLaunch = fileModificationDate(at: spliceKitLogURL)
@@ -880,7 +892,14 @@ class PatcherModel: ObservableObject {
             }
             return parts.isEmpty ? "true" : parts.joined(separator: " && ")
         }
+        // Strip extended attributes immediately before signing. Steps between
+        // bundle copy and sign — insert_dylib rewriting the Mach-O, PlistBuddy
+        // edits to Info.plist, file copies from quarantined sources — can leave
+        // com.apple.FinderInfo or resource forks behind that trigger codesign's
+        // "resource fork, Finder information, or similar detritus not allowed"
+        // rejection.
         var signResult = shellResult("""
+            xattr -cr '\(moddedApp)' 2>/dev/null && \
             \(signBRAW(quotedIdentity)) && \
             codesign --force --options runtime --sign \(quotedIdentity) '\(moddedApp)/Contents/Frameworks/SpliceKit.framework' 2>&1 && \
             codesign --force --options runtime --sign \(quotedIdentity) --entitlements '\(entitlements)' '\(moddedApp)' 2>&1
@@ -892,6 +911,7 @@ class PatcherModel: ObservableObject {
             }
             signIdentity = "-"
             signResult = shellResult("""
+                xattr -cr '\(moddedApp)' 2>/dev/null && \
                 \(signBRAW("-")) && \
                 codesign --force --options runtime --sign - '\(moddedApp)/Contents/Frameworks/SpliceKit.framework' 2>&1 && \
                 codesign --force --options runtime --sign - --entitlements '\(entitlements)' '\(moddedApp)' 2>&1
@@ -1107,7 +1127,14 @@ class PatcherModel: ObservableObject {
             }
             return parts.isEmpty ? "true" : parts.joined(separator: " && ")
         }
+        // Strip extended attributes immediately before signing. Steps between
+        // bundle copy and sign — insert_dylib rewriting the Mach-O, PlistBuddy
+        // edits to Info.plist, file copies from quarantined sources — can leave
+        // com.apple.FinderInfo or resource forks behind that trigger codesign's
+        // "resource fork, Finder information, or similar detritus not allowed"
+        // rejection.
         var signResult = shellResult("""
+            xattr -cr '\(moddedApp)' 2>/dev/null && \
             \(signBRAW(quotedIdentity)) && \
             codesign --force --options runtime --sign \(quotedIdentity) '\(moddedApp)/Contents/Frameworks/SpliceKit.framework' 2>&1 && \
             codesign --force --options runtime --sign \(quotedIdentity) --entitlements '\(entitlements)' '\(moddedApp)' 2>&1
@@ -1119,6 +1146,7 @@ class PatcherModel: ObservableObject {
             }
             signIdentity = "-"
             signResult = shellResult("""
+                xattr -cr '\(moddedApp)' 2>/dev/null && \
                 \(signBRAW("-")) && \
                 codesign --force --options runtime --sign - '\(moddedApp)/Contents/Frameworks/SpliceKit.framework' 2>&1 && \
                 codesign --force --options runtime --sign - --entitlements '\(entitlements)' '\(moddedApp)' 2>&1


### PR DESCRIPTION
## Summary

Two small Sentry-driven patcher fixes, landing on top of the #63 / #67 merges earlier today.

- **Fixes APPLE-MACOS-A** (3 users, 15 events, escalating) — codesign was rejecting the re-sign with `resource fork, Finder information, or similar detritus not allowed`. An initial `xattr -cr` runs right after the FCP copy, but intermediate patch steps (`insert_dylib` rewriting the Mach-O, `PlistBuddy` edits to `Info.plist`, BRAW bundle copies from quarantined sources) can re-attach `com.apple.FinderInfo` or resource forks between that strip and the final sign. Added `xattr -cr` as the first step of the sign shell pipeline in both `runPatch` and `runUpdate`, and mirrored it on the ad-hoc fallback path.
- **Fixes APPLE-MACOS-D** — `NSWorkspace.openApplication` surfaced a missing modded bundle as a raw `NSCocoaErrorDomain Code 4` in Sentry. `canLaunchFCP` only inspects patcher state; it does not verify the bundle still exists on disk. Added a `FileManager.fileExists` pre-flight check at the top of `launch()` with a clear log message telling the user to re-run the patch.

Total diff: 1 file, 28 insertions, 0 deletions.

## Also resolves (fixed in #63, linked here for Sentry auto-close)

- **Resolves APPLE-MACOS-8** — `SIGABRT … -[__NSDictionaryM __setObject:forKey:]: object cannot be nil (key: MediaExtensionContainingBundleName)`. Fixed by the `@try/@catch` wrapper around `-[FFMediaExtensionManager copyDecoderInfo:]` in `SpliceKitMediaExtensionGuard.m` that swallows exactly that `NSInvalidArgumentException` from `VTCopyVideoDecoderExtensionProperties`.
- **Resolves APPLE-MACOS-9** — `EXC_BAD_ACCESS: KERN_INVALID_ADDRESS at 0x62726177`. `0x62726177` is ASCII `"braw"`. Fixed by declaring the FourCC parameter to `copyDecoderInfo:` as `uintptr_t` instead of `id` — the original `id` signature made ARC emit `objc_storeStrong` on entry, which tried to dereference the raw FourCC value as an object pointer.

## Test plan

- [x] `xcodebuild -project patcher/SpliceKit.xcodeproj -scheme SpliceKit -configuration Debug build` — clean (only a pre-existing unused-var warning unrelated to this change)
- [ ] Fresh install on a machine with quarantine-tagged FCP — verify the final sign succeeds where it previously hit the "detritus not allowed" error
- [ ] Run an update (`runUpdate` path) on an already-patched bundle — verify the sign still succeeds
- [ ] Delete the modded bundle and click "Launch FCP" — verify the clear log message appears and no Sentry event fires