### PR TITLE
Harden two regressions caught in post-3.3.2 review

### DIFF
--- a/Sources/SpliceKitBRAWDecoderInProcess.mm
+++ b/Sources/SpliceKitBRAWDecoderInProcess.mm
@@ -61,6 +61,29 @@ int SpliceKitBRAWLookupEyeForFormatDescription(CMFormatDescriptionRef fd);
 
 namespace splicekit_braw_decoder {
 
+struct DecoderRegistrationState {
+    FourCharCode codec;
+    BOOL registered;
+};
+
+static DecoderRegistrationState kDecoderRegistrationStates[] = {
+    { 'braw', NO },
+    { 'brxq', NO },
+    { 'brst', NO },
+    { 'brvn', NO },
+    { 'brs2', NO },
+    { 'brxh', NO },
+};
+
+static DecoderRegistrationState *registrationStateForCodec(FourCharCode codec) {
+    for (size_t i = 0; i < sizeof(kDecoderRegistrationStates) / sizeof(DecoderRegistrationState); ++i) {
+        if (kDecoderRegistrationStates[i].codec == codec) {
+            return &kDecoderRegistrationStates[i];
+        }
+    }
+    return nullptr;
+}
+
 #if defined(__x86_64__)
 constexpr size_t kCMBasePadSize = 4;
 #else
@@ -515,23 +538,31 @@ extern "C" OSStatus SpliceKitBRAWInProcess_CreateInstance(FourCharCode /*codecTy
 
 // -------- Public registration entry point ------------------------------------
 
+extern "C" BOOL SpliceKitBRAW_isInProcessDecoderRegisteredForCodec(uint32_t codec) {
+    splicekit_braw_decoder::DecoderRegistrationState *state =
+        splicekit_braw_decoder::registrationStateForCodec((FourCharCode)codec);
+    return state ? state->registered : NO;
+}
+
 extern "C" BOOL SpliceKitBRAW_registerInProcessDecoder(void) {
     static dispatch_once_t once;
     static BOOL registered = NO;
     dispatch_once(&once, ^{
         // All BRAW FourCC variants we support. Each call binds one codec type
         // to our CreateInstance factory in VT's in-process decoder registry.
-        FourCharCode codecs[] = { 'braw', 'brxq', 'brst', 'brvn', 'brs2', 'brxh' };
         BOOL anyOK = NO;
-        for (size_t i = 0; i < sizeof(codecs) / sizeof(FourCharCode); ++i) {
-            OSStatus s = VTRegisterVideoDecoder(codecs[i],
+        for (size_t i = 0; i < sizeof(splicekit_braw_decoder::kDecoderRegistrationStates) / sizeof(splicekit_braw_decoder::DecoderRegistrationState); ++i) {
+            FourCharCode codec = splicekit_braw_decoder::kDecoderRegistrationStates[i].codec;
+            OSStatus s = VTRegisterVideoDecoder(codec,
                 &splicekit_braw_decoder::SpliceKitBRAWInProcess_CreateInstance);
-            if (s == noErr) anyOK = YES;
+            BOOL didRegister = (s == noErr);
+            splicekit_braw_decoder::kDecoderRegistrationStates[i].registered = didRegister;
+            if (didRegister) anyOK = YES;
             NSString *msg = [NSString stringWithFormat:@"[decoder-in-process] register %c%c%c%c status=%d",
-                (char)((codecs[i] >> 24) & 0xFF),
-                (char)((codecs[i] >> 16) & 0xFF),
-                (char)((codecs[i] >> 8) & 0xFF),
-                (char)(codecs[i] & 0xFF),
+                (char)((codec >> 24) & 0xFF),
+                (char)((codec >> 16) & 0xFF),
+                (char)((codec >> 8) & 0xFF),
+                (char)(codec & 0xFF),
                 (int)s];
             NSLog(@"%@", msg);
             // Also append to the BRAW log so we can diagnose without Console.

--- a/Sources/SpliceKitMediaExtensionGuard.m
+++ b/Sources/SpliceKitMediaExtensionGuard.m
@@ -82,21 +82,15 @@ static IMP sOrigIsAppExclusiveDecoder = NULL;
 static IMP sOrigIsDecoderUsingMediaExtension = NULL;
 static BOOL sMediaExtensionGuardInstalled = NO;
 
+extern BOOL SpliceKitBRAW_isInProcessDecoderRegisteredForCodec(uint32_t fourcc);
+
 // Codecs SpliceKit handles in-process via VTRegisterVideoDecoder
 // (SpliceKitBRAWDecoderInProcess.mm registers all six variants on startup).
-// When FFMediaExtensionManager is asked for one of these we return nil so
-// FCP's decoder selection falls past the Media Extension layer and lands on
-// our in-process registration. Synced with the FourCC list in
-// SpliceKitBRAWDecoderInProcess.mm:524 and the format-description filter in
-// SpliceKitBRAW.mm:1743.
-static BOOL MEG_isSpliceKitOwnedCodec(uint32_t fourcc) {
-    switch (fourcc) {
-    case 'braw': case 'brxq': case 'brst':
-    case 'brvn': case 'brs2': case 'brxh':
-        return YES;
-    default:
-        return NO;
-    }
+// Only codecs whose in-process registration actually succeeded should bypass
+// Media Extension routing; otherwise we leave FCP's original fallback path
+// in place.
+static BOOL MEG_shouldBypassMediaExtensionRouting(uint32_t fourcc) {
+    return SpliceKitBRAW_isInProcessDecoderRegisteredForCodec(fourcc);
 }
 
 static NSString *MEG_fourCCString(uint32_t fourcc) {
@@ -171,7 +165,7 @@ static id MEG_swizzledCopyDecoderInfo(id self, SEL _cmd, uintptr_t arg) {
     // register; truncate to read it back without dereferencing.
     uint32_t fourcc = (uint32_t)arg;
 
-    if (MEG_isSpliceKitOwnedCodec(fourcc)) {
+    if (MEG_shouldBypassMediaExtensionRouting(fourcc)) {
         MEG_logRoutingDecisionOnce(fourcc);
         return nil;
     }
@@ -203,7 +197,7 @@ static id MEG_swizzledCopyProcessorInfo(id self, SEL _cmd, uintptr_t arg) {
     if (!sOrigCopyProcessorInfo) return nil;
     uint32_t fourcc = (uint32_t)arg;
 
-    if (MEG_isSpliceKitOwnedCodec(fourcc)) {
+    if (MEG_shouldBypassMediaExtensionRouting(fourcc)) {
         MEG_logRoutingDecisionOnce(fourcc);
         return nil;
     }
@@ -221,24 +215,24 @@ static id MEG_swizzledCopyProcessorInfo(id self, SEL _cmd, uintptr_t arg) {
 
 // isAppExclusiveDecoder: returns YES when FCP should treat the in-app
 // decoder as authoritative (skipping Media Extension lookup) for the given
-// FourCC. BRAW decoders SpliceKit owns get a hard YES here; everything
-// else passes through to FCP's normal logic.
+// FourCC. We only force YES when that exact BRAW variant is registered
+// in-process; everything else passes through to FCP's normal logic.
 static BOOL MEG_swizzledIsAppExclusiveDecoder(id self, SEL _cmd, uintptr_t arg) {
     uint32_t fourcc = (uint32_t)arg;
-    if (MEG_isSpliceKitOwnedCodec(fourcc)) return YES;
+    if (MEG_shouldBypassMediaExtensionRouting(fourcc)) return YES;
     if (!sOrigIsAppExclusiveDecoder) return NO;
     return ((BOOL (*)(id, SEL, uintptr_t))sOrigIsAppExclusiveDecoder)(self, _cmd, arg);
 }
 
 // isDecoderUsingMediaExtension: returns YES when FCP routes the codec
-// through a Media Extension. We override to NO for BRAW so any callers
-// that gate on this predicate (cache invalidation, Inspector display,
-// asset-rep-provider selection in -[FFAsset _newMediaRepProviderForQuality:])
-// believe FCP is using the in-process path even if a third-party Media
-// Extension is registered for the codec.
+// through a Media Extension. We override to NO only for BRAW variants that
+// are currently registered in-process so any callers that gate on this
+// predicate (cache invalidation, Inspector display, asset-rep-provider
+// selection in -[FFAsset _newMediaRepProviderForQuality:]) stay aligned with
+// the actual decoder route.
 static BOOL MEG_swizzledIsDecoderUsingMediaExtension(id self, SEL _cmd, uintptr_t arg) {
     uint32_t fourcc = (uint32_t)arg;
-    if (MEG_isSpliceKitOwnedCodec(fourcc)) return NO;
+    if (MEG_shouldBypassMediaExtensionRouting(fourcc)) return NO;
     if (!sOrigIsDecoderUsingMediaExtension) return NO;
     return ((BOOL (*)(id, SEL, uintptr_t))sOrigIsDecoderUsingMediaExtension)(self, _cmd, arg);
 }

--- a/patcher/SpliceKit/Models/PatcherModel.swift
+++ b/patcher/SpliceKit/Models/PatcherModel.swift
@@ -92,6 +92,7 @@ class PatcherModel: ObservableObject {
     @Published private(set) var isLaunchInProgress = false
     @Published private(set) var isModdedFCPRunning = false
 
+    private var isLaunchRequestPending = false
     private var launchedFCPRunningApp: NSRunningApplication?
     private var launchedFCPTerminationObserver: NSObjectProtocol?
     private var launchMonitorTask: Task<Void, Never>?
@@ -248,6 +249,8 @@ class PatcherModel: ObservableObject {
 
         if isRunning {
             isLaunchInProgress = false
+        } else if isLaunchRequestPending {
+            isLaunchInProgress = true
         } else if launchedFCPRunningApp?.isTerminated ?? true {
             isLaunchInProgress = false
             launchedFCPRunningApp = nil
@@ -529,6 +532,7 @@ class PatcherModel: ObservableObject {
 
         launchMonitorTask?.cancel()
         launchMonitorTask = nil
+        isLaunchRequestPending = true
         isLaunchInProgress = true
         appendLog("Launching modded FCP...")
         appendLog("Launch binary: \(binary)")
@@ -564,6 +568,7 @@ class PatcherModel: ObservableObject {
             Task { @MainActor in
                 guard let self else { return }
                 if let error = error {
+                    self.isLaunchRequestPending = false
                     self.launchedFCPRunningApp = nil
                     self.isLaunchInProgress = false
                     self.syncModdedFCPRunningState()
@@ -574,11 +579,13 @@ class PatcherModel: ObservableObject {
                     return
                 }
                 guard let runningApp else {
+                    self.isLaunchRequestPending = false
                     self.isLaunchInProgress = false
                     self.syncModdedFCPRunningState()
                     self.appendLog("Final Cut Pro launched but no NSRunningApplication returned")
                     return
                 }
+                self.isLaunchRequestPending = false
                 self.launchedFCPRunningApp = runningApp
                 self.appendLog("Spawned Final Cut Pro pid \(runningApp.processIdentifier)")
                 self.observeLaunchedAppTermination(
@@ -626,6 +633,7 @@ class PatcherModel: ObservableObject {
             appendLog("Removed \(destDir)")
             status = .notInstalled
             bridgeConnected = false
+            isLaunchRequestPending = false
             isLaunchInProgress = false
             isModdedFCPRunning = false
             launchedFCPRunningApp = nil
@@ -682,6 +690,7 @@ class PatcherModel: ObservableObject {
         shell("pkill -f 'Applications/SpliceKit' 2>/dev/null; sleep 1")
         try? FileManager.default.removeItem(atPath: moddedApp)
         bridgeConnected = false
+        isLaunchRequestPending = false
         isLaunchInProgress = false
         isModdedFCPRunning = false
         launchedFCPRunningApp = nil
@@ -1443,6 +1452,7 @@ class PatcherModel: ObservableObject {
             launchMonitorTask?.cancel()
             launchMonitorTask = nil
         }
+        isLaunchRequestPending = false
         if let observer = launchedFCPTerminationObserver {
             NSWorkspace.shared.notificationCenter.removeObserver(observer)
             launchedFCPTerminationObserver = nil


### PR DESCRIPTION
## Summary

Two regressions surfaced during a post-merge review of #63 and #67. Neither is firing in Sentry — caught in review, not in production — so no version bump. Lands on `main` for the next release.

### Patcher launch-state race (post-#67 regression)

`launch()` sets `isLaunchInProgress = true` before `NSWorkspace.openApplication` fires its async completion. In that window `launchedFCPRunningApp` is still `nil`, so if `syncModdedFCPRunningState` lands (from `launchMonitorTask`'s 12-second tick or a bridge poll) its existing branch — `launchedFCPRunningApp?.isTerminated ?? true` — evaluates `true` and flips `isLaunchInProgress` back to `false`. The UI re-enables the Launch button and a second click queues a duplicate `openApplication` before the first completes.

Added `isLaunchRequestPending` set before the NSWorkspace call, cleared in every completion path (error/no-app/success) and in uninstall/rebuild/termination cleanup, and honoured by `syncModdedFCPRunningState` so a sync landing in the gap keeps the UI locked.

### BRAW Media Extension guard (post-#63 regression)

`SpliceKitBRAW_registerInProcessDecoder` already tracks per-FourCC registration success via its `anyOK` variable — `VTRegisterVideoDecoder` can fail for any of the six BRAW variants. But `SpliceKitMediaExtensionGuard.m` used a hardcoded switch over all six FourCCs and returned `YES` unconditionally. So if a variant failed to register, SpliceKit would still claim authority over it (`copyDecoderInfo:` → nil, `isAppExclusiveDecoder:` → YES), blocking Media Extension fallback while having no working in-process decoder — silent playback failure.

Tracked registration per-FourCC in a static `DecoderRegistrationState` array in `SpliceKitBRAWDecoderInProcess.mm`, exported `SpliceKitBRAW_isInProcessDecoderRegisteredForCodec()`, and made the guard consult it. Happy path unchanged; defensive behaviour correct when registration partially fails.

## Test plan

- [x] `make` — SpliceKit dylib builds clean, `_SpliceKitBRAW_isInProcessDecoderRegisteredForCodec` is exported in the universal binary, no undefined `_SpliceKit_*` symbols (the 3.3.2 build-time guard still holds)
- [x] `xcodebuild -project patcher/SpliceKit.xcodeproj -scheme SpliceKit -configuration Debug build` — clean (only pre-existing `repoDir` unused-var warning in `runUpdate`, unrelated)
- [ ] Live FCP test: fresh patch, launch FCP, rapid double-click the Launch button — only one FCP instance should spawn
- [ ] Live FCP test: BRAW playback still works when all six variants register successfully (happy path)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two regressions found after 3.3.2 review. Prevents duplicate FCP launches and ensures BRAW correctly falls back to Media Extension when a variant isn’t registered in-process.

- **Bug Fixes**
  - Patcher launch race: add `isLaunchRequestPending` set before `NSWorkspace.openApplication`, honored by `syncModdedFCPRunningState`, and cleared on all completion/cleanup paths to keep the Launch button locked and avoid duplicate spawns.
  - BRAW guard: track per-FourCC registration in a static table, expose `SpliceKitBRAW_isInProcessDecoderRegisteredForCodec()`, and only bypass Media Extension when that exact variant is registered, preventing silent playback failures on partial registration.

<sup>Written for commit 53816c874029f08212b4bc995f2aa9e9132a79a9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

