### PR TITLE
Point .mcp.json at local SpliceKit checkout

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,8 +1,8 @@
 {
   "mcpServers": {
     "splicekit": {
-      "command": "/Users/briantate/.venvs/splicekit-mcp/bin/python",
-      "args": ["/Users/briantate/Documents/GitHub/SpliceKit/mcp/server.py"]
+      "command": "/Users/sunguru/.venvs/splicekit-mcp/bin/python",
+      "args": ["/Users/sunguru/SpliceKit/mcp/server.py"]
     }
   }
 }


### PR DESCRIPTION
## Summary
- `.mcp.json` hardcoded the previous contributor's (`briantate`) Python venv path and repo checkout path for the `splicekit` MCP server, which meant the MCP server failed to resolve/start on any other machine.
- Updates `command` and `args` to this machine's venv (`/Users/sunguru/.venvs/splicekit-mcp/bin/python`) and repo location (`/Users/sunguru/SpliceKit/mcp/server.py`).

## Note for reviewer
`.mcp.json` appears to store an absolute, machine-specific path rather than something portable (e.g. a relative path, `$HOME`-relative path, or an env var) — the same pattern was already present for `briantate`'s machine before this change. This PR follows that existing convention rather than introducing a new one. If a portable form is preferred going forward (so each contributor doesn't need to hand-edit this file), happy to follow up with that instead — flagging in case that's the better long-term fix.

## Test plan
- [x] Confirmed `splicekit` MCP server connects and `bridge_status` returns a healthy response against a running Final Cut Pro instance after this change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Points `.mcp.json` `splicekit` MCP server to this machine’s venv and repo paths so the server starts locally. Previously it used another contributor’s absolute paths and failed to resolve; now it uses `/Users/sunguru/.venvs/splicekit-mcp/bin/python` and `/Users/sunguru/SpliceKit/mcp/server.py`, which is still machine-specific.

**Review notes**
- Updates only `command` and `args` for `splicekit`; no runtime code changes.
- Keeps the existing absolute-path pattern; a portable approach can follow in a separate PR.

**Developer action**
- Update these paths in `.mcp.json` to your local venv and repo to run the `splicekit` server on your machine.

<sup>Written for commit ebd5290b97a1d061898b8b765a956714032151cc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/elliotttate/SpliceKit/pull/83?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

