### PR TITLE
Fix transcription reliability: whisper deploy, Parakeet batch resilience, and FluidAudio build

### DIFF
--- a/patcher/SpliceKit/Models/PatcherModel.swift
+++ b/patcher/SpliceKit/Models/PatcherModel.swift
@@ -270,13 +270,22 @@ class PatcherModel: ObservableObject {
 
     private func deployTools(to toolsDir: String,
                              silenceBin: String,
-                             parakeetBin: String) async {
+                             parakeetBin: String,
+                             whisperBin: String) async {
         shell("mkdir -p \(shellQuote(toolsDir))")
         if FileManager.default.fileExists(atPath: silenceBin) {
             shell("cp \(shellQuote(silenceBin)) \(shellQuote(toolsDir + "/silence-detector"))")
         }
         if FileManager.default.fileExists(atPath: parakeetBin) {
             shell("cp \(shellQuote(parakeetBin)) \(shellQuote(toolsDir + "/parakeet-transcriber"))")
+        }
+        if FileManager.default.fileExists(atPath: whisperBin) {
+            shell("cp \(shellQuote(whisperBin)) \(shellQuote(toolsDir + "/whisper-transcriber"))")
+        } else {
+            // Loud warning instead of silently skipping: a missing whisper-transcriber
+            // leaves the social-captions Whisper engines reporting "not found" at runtime
+            // even though the patch otherwise "succeeds".
+            await logAsync("WARNING: whisper-transcriber not staged; Whisper caption engines will be unavailable. Re-download the patcher if this persists.")
         }
 
         for toolName in ["yt-dlp", "ffmpeg"] {
@@ -889,6 +898,12 @@ class PatcherModel: ObservableObject {
             shell("cp '\(bundledParakeet)' '\(parakeetBin)'")
         }
 
+        let whisperBin = buildDir + "/whisper-transcriber"
+        let bundledWhisper = (Bundle.main.resourcePath ?? "") + "/tools/whisper-transcriber"
+        if FileManager.default.fileExists(atPath: bundledWhisper) {
+            shell("cp '\(bundledWhisper)' '\(whisperBin)'")
+        }
+
         await completeStepAsync(.buildDylib)
 
         // Step 4: Create macOS framework bundle (Versions/A + symlinks)
@@ -960,7 +975,7 @@ class PatcherModel: ObservableObject {
 
         // Deploy tools
         let toolsDir = NSHomeDirectory() + "/Applications/SpliceKit/tools"
-        await deployTools(to: toolsDir, silenceBin: silenceBin, parakeetBin: parakeetBin)
+        await deployTools(to: toolsDir, silenceBin: silenceBin, parakeetBin: parakeetBin, whisperBin: whisperBin)
 
         await logAsync("Framework installed")
         await completeStepAsync(.installFramework)
@@ -1167,6 +1182,12 @@ class PatcherModel: ObservableObject {
         if FileManager.default.fileExists(atPath: bundledParakeet) {
             shell("cp '\(bundledParakeet)' '\(parakeetBin)'")
         }
+
+        let whisperBin = buildDir + "/whisper-transcriber"
+        let bundledWhisper = (Bundle.main.resourcePath ?? "") + "/tools/whisper-transcriber"
+        if FileManager.default.fileExists(atPath: bundledWhisper) {
+            shell("cp '\(bundledWhisper)' '\(whisperBin)'")
+        }
         await completeStepAsync(.buildDylib)
 
         // Install framework (overwrite existing binary)
@@ -1230,7 +1251,7 @@ class PatcherModel: ObservableObject {
 
         // Deploy tools
         let toolsDir = NSHomeDirectory() + "/Applications/SpliceKit/tools"
-        await deployTools(to: toolsDir, silenceBin: silenceBin, parakeetBin: parakeetBin)
+        await deployTools(to: toolsDir, silenceBin: silenceBin, parakeetBin: parakeetBin, whisperBin: whisperBin)
 
         await logAsync("Framework updated")
         await completeStepAsync(.installFramework)

--- a/tools/parakeet-transcriber/Package.swift
+++ b/tools/parakeet-transcriber/Package.swift
@@ -6,7 +6,11 @@ let package = Package(
     name: "parakeet-transcriber",
     platforms: [.macOS(.v14)],
     dependencies: [
-        .package(url: "https://github.com/FluidInference/FluidAudio.git", from: "0.12.0"),
+        // FluidAudio is pre-1.0, so minor releases carry breaking API changes. The old
+        // floating `from: "0.12.0"` resolved to whatever 0.x was latest, silently breaking
+        // the build (e.g. 0.13+ replaced AsrManager.transcribe(_:source:) with
+        // transcribe(_:decoderState:language:)). Pin to a known-compatible 0.15.x line.
+        .package(url: "https://github.com/FluidInference/FluidAudio.git", .upToNextMinor(from: "0.15.6")),
     ],
     targets: [
         .executableTarget(

--- a/tools/parakeet-transcriber/Sources/main.swift
+++ b/tools/parakeet-transcriber/Sources/main.swift
@@ -301,7 +301,11 @@ Task {
                 reportProgress(pct, "Transcribing \(index+1)/\(Int(totalFiles)): \(fileURL.lastPathComponent)...")
             }
             do {
-                let result = try await manager.transcribe(fileURL, source: .system)
+                // FluidAudio 0.13+ replaced transcribe(_:source:) with a decoder-state
+                // API. Each batch entry is an independent clip, so use a fresh decoder
+                // state per file (no cross-file streaming context).
+                var decoderState = try TdtDecoderState()
+                let result = try await manager.transcribe(fileURL, decoderState: &decoderState)
                 asrResults.append((index: index, file: entry.file, result: result))
             } catch {
                 // A single undecodable input (a still image, PDF, or a clip with no

--- a/tools/parakeet-transcriber/Sources/main.swift
+++ b/tools/parakeet-transcriber/Sources/main.swift
@@ -289,6 +289,7 @@ Task {
 
         // Phase 1: Transcribe all files (ASR actor serializes these, runs on ANE)
         var asrResults: [(index: Int, file: String, result: ASRResult)] = []
+        var transcriptionErrors: [String: String] = [:]
         for (index, entry) in batchEntries.enumerated() {
             let fileURL = URL(fileURLWithPath: entry.file)
             guard FileManager.default.fileExists(atPath: entry.file) else {
@@ -299,8 +300,18 @@ Task {
                 let pct = 0.20 + (0.50 * Double(index) / totalFiles)
                 reportProgress(pct, "Transcribing \(index+1)/\(Int(totalFiles)): \(fileURL.lastPathComponent)...")
             }
-            let result = try await manager.transcribe(fileURL, source: .system)
-            asrResults.append((index: index, file: entry.file, result: result))
+            do {
+                let result = try await manager.transcribe(fileURL, source: .system)
+                asrResults.append((index: index, file: entry.file, result: result))
+            } catch {
+                // A single undecodable input (a still image, PDF, or a clip with no
+                // audio track — e.g. AVFoundation kAudioFileInvalidFileError /
+                // kAudioFileUnsupportedFileTypeError) must not abort the whole batch.
+                // Record it, log it, and keep transcribing the remaining files.
+                transcriptionErrors[entry.file] = error.localizedDescription
+                printError("Skipping \(fileURL.lastPathComponent): \(error.localizedDescription)")
+                continue
+            }
         }
 
         if showProgress { reportProgress(0.70, "Transcription complete — \(asrResults.count) file(s)") }
@@ -340,7 +351,8 @@ Task {
         for entry in batchEntries {
             if !processedFiles.contains(entry.file) {
                 if batchMode {
-                    allResults.append(["file": entry.file, "words": [] as [Any], "error": "File not found"])
+                    let reason = transcriptionErrors[entry.file] ?? "File not found"
+                    allResults.append(["file": entry.file, "words": [] as [Any], "error": reason])
                 }
             }
         }


### PR DESCRIPTION
# Fix transcription reliability: whisper deploy, Parakeet batch resilience, and FluidAudio build

## Summary

Three related fixes that make on-device transcription work end-to-end again. Each is an independent, reviewable commit.

1. **Patcher never deployed `whisper-transcriber`** → the social-captions Whisper engines report "not found".
2. **Parakeet aborts the entire batch when one input has no decodable audio** (issue #78) → timelines that mix stills/graphics/PDFs with audio produce **zero** words.
3. **`parakeet-transcriber` no longer compiles against any published FluidAudio release** → the tool can't be built from a clean checkout.

All three were verified locally on FCP 11.1 / SpliceKit 3.3.8 (Apple Silicon, macOS 15.6).

---

## 1. Patcher deploys `whisper-transcriber` (`104fd0d`)

`patcher/SpliceKit/Models/PatcherModel.swift` staged and deployed only `silence-detector` and `parakeet-transcriber`; `deployTools()` had no `whisperBin` parameter. `whisper-transcriber` ships in the patcher app bundle and the v3.3.8 notes say it's included so the Whisper large-v3 / large-v3-turbo caption engines "actually work" — but the deploy path never copied it into `~/Applications/SpliceKit/tools/`.

Result: a clean patch reports success, yet the captions panel fails with:

> Whisper large-v3 transcriber not found. Re-run the SpliceKit patcher, or pick a different engine.

Re-running never helps — every run repeats the same incomplete tool set.

**Fix:** stage `whisper-transcriber` in both the full-patch and update paths (mirroring the existing parakeet/silence staging), add a `whisperBin` parameter to `deployTools()`, and emit a loud `WARNING` when it's absent so the failure is visible in the patch log instead of silently degrading transcription.

> Note: the separate `patcher/SpliceKitPatcher/main.swift` target already copies whisper correctly — only the shipped SwiftUI patcher (`PatcherModel.swift`) was missing it.

## 2. Parakeet batch resilience (`d0900d1`) — fixes #78

In `tools/parakeet-transcriber/Sources/main.swift`, the Phase-1 batch loop transcribed each file with a bare `try await manager.transcribe(...)` and no per-file error handling. When one entry can't be decoded as audio — a still image, a PDF, or a clip with no audio track — AVFoundation throws `kAudioFileInvalidFileError` / `kAudioFileUnsupportedFileTypeError` (surfaced as `com.apple.coreaudio.avfaudio error 1685348671` / `1954115647`). That error propagated out of the loop to the outer `catch`, set `exitCode = 1`, and produced zero words for the **entire** batch.

Timelines routinely mix stills/graphics with audio clips, so a single non-audio item silently broke transcription for the whole timeline. This is issue #78 — both avfaudio subcodes are the same root cause.

**Fix:** wrap the per-file transcribe in `do`/`catch` (mirroring the diarization phase, which already tolerates per-file failures). A failing file is recorded, logged (`Skipping <file>: <reason>`), and skipped so the remaining files still transcribe. Batch results report each skipped file's real error instead of a blanket "File not found".

## 3. Build against current FluidAudio (`57b1ef0`)

`parakeet-transcriber` did not compile against **any** published FluidAudio release: `main.swift` uses `.tdtCtc110m` (added in FluidAudio 0.13.7) together with `AsrManager.transcribe(_:source:)` (removed after 0.13.0), so no single version satisfies both. The floating `from: "0.12.0"` masked this by resolving to whatever 0.x was newest.

**Fix:**
- `Package.swift`: pin FluidAudio to `.upToNextMinor(from: "0.15.6")` so the pre-1.0 dependency can't silently pull a version with breaking API changes.
- `main.swift`: migrate the one incompatible call from `transcribe(fileURL, source: .system)` to the current `transcribe(fileURL, decoderState: &state)` API, using a fresh `TdtDecoderState` per batch entry (independent clips, no streaming context).

(0.15.6 is compatible with the entire file — `.tdtCtc110m`, `.v2`/`.v3`, model loading, diarizer — except that single call. No features dropped.)

---

## Verification

- **Patcher (#1):** `swiftc -typecheck` of all patcher app sources against the built Sentry/Sparkle frameworks → **0 errors**.
- **Parakeet (#2, #3):** `swift build -c release` against FluidAudio 0.15.6 → **succeeds**. Running a batch of `[non-audio .png, spoken .aiff]`:
  - the `.png` throws `avfaudio error 1954115647` and is **skipped** (logged, recorded), instead of aborting the batch;
  - the audio transcribes to accurate word-level output — *"The quick brown fox jumps over the lazy dog."* with per-word timings.

## Notes for reviewers

- Commits are independent; #1 (patcher) is unrelated to #2/#3 (the transcriber tool) and can be taken separately. #2 and #3 are coupled — #3 is what lets the tool (and therefore #2) build at all.
- `Package.resolved` is gitignored per repo convention, so it's not included.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores end-to-end on-device transcription by deploying Whisper, making Parakeet batch-safe, and pinning `FluidAudio` for a reliable build. Previously the patcher omitted `whisper-transcriber`, Parakeet aborted on a single non-audio file, and `parakeet-transcriber` could not compile; now Whisper is deployed with a clear warning if missing, Parakeet skips and logs bad files, and the tool builds against `FluidAudio` 0.15.6 using the decoder-state API.

- Patcher: stage and deploy `whisper-transcriber` in both full and update paths; add `whisperBin` to `deployTools()`; log a WARNING when Whisper is absent.
- Parakeet: wrap per-file transcribe in do/catch, log “Skipping <file>: <reason>”, and include the real per-file error in batch results instead of aborting the batch (fixes #78).
- Build: pin `FluidAudio` to `.upToNextMinor(from: "0.15.6")` and migrate to `transcribe(fileURL, decoderState:&state)` with a fresh `TdtDecoderState` per file.

- Rollout: Users must re-run the SwiftUI patcher once to deploy `whisper-transcriber` into ~/Applications/SpliceKit/tools/. No config or data migrations.

<sup>Written for commit 57b1ef00c0a16e03535449571210a176504f38e8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/elliotttate/SpliceKit/pull/85?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

