### PR TITLE
Fix from-source build without the Blackmagic RAW SDK and repair patch_fcp.sh

### DIFF
--- a/Sources/SpliceKitBRAW.mm
+++ b/Sources/SpliceKitBRAW.mm
@@ -5599,6 +5599,17 @@ SPLICEKIT_BRAW_EXTERN_C NSDictionary *SpliceKit_handleBRAWDescribeImmersive(NSDi
     return SpliceKit_handleBRAWProbe(params);
 }
 
+// Local fix (no Blackmagic RAW SDK installed): SpliceKit.m and SpliceKitServer.m
+// call these unconditionally, but upstream's #else branch omits them, which
+// leaves undefined SpliceKit_* symbols and fails the Makefile's link check.
+SPLICEKIT_BRAW_EXTERN_C void SpliceKit_bootstrapBRAWAtLaunchPhase(NSString *phase) {
+    (void)phase;
+}
+
+SPLICEKIT_BRAW_EXTERN_C NSDictionary *SpliceKit_handleBRAWAVProbe(NSDictionary *params) {
+    return SpliceKit_handleBRAWProbe(params);
+}
+
 SPLICEKIT_BRAW_EXTERN_C NSDictionary *SpliceKit_handleBRAWReadMotionSamples(NSDictionary *params) {
     return SpliceKit_handleBRAWProbe(params);
 }

--- a/patcher/patch_fcp.sh
+++ b/patcher/patch_fcp.sh
@@ -51,10 +51,13 @@ step()  { echo -e "\n${CYAN}${BOLD}=== $* ===${NC}"; }
 detect_sign_identity() {
     /usr/bin/security find-identity -v -p codesigning 2>/dev/null | \
         awk '
-            /"Apple Development:/ { print $2; exit }
+            /"Apple Development:/ { print $2; printed = 1; exit }
             /"Developer ID Application:/ && developer == "" { developer = $2 }
             /[0-9]+\) [0-9A-F]+ "/ && first == "" { first = $2 }
             END {
+                # Local fix: awk still runs END after exit, which printed a second
+                # identity and broke codesign ("no identity found").
+                if (printed) exit;
                 if (developer != "") print developer;
                 else if (first != "") print first;
             }'
@@ -320,16 +323,12 @@ if [ -d "$LUA_DIR" ]; then
     log "Built: $LUA_LIB"
 fi
 
-info "Compiling ${#SOURCES[@]} source files..."
-clang -arch arm64 -arch x86_64 \
-    -mmacosx-version-min=14.0 \
-    -framework Foundation -framework AppKit -framework AVFoundation -framework Speech -framework CoreServices \
-    -fobjc-arc -fmodules -Wno-deprecated-declarations \
-    -undefined dynamic_lookup -dynamiclib \
-    -install_name @rpath/SpliceKit.framework/Versions/A/SpliceKit \
-    -I "$REPO_DIR/Sources" \
-    "${SOURCES[@]}" $LUA_FLAGS \
-    -o "$BUILD_DIR/SpliceKit" 2>&1
+info "Compiling ${#SOURCES[@]} source files via Makefile (canonical flags: Sentry, Metal, Vision, C++)..."
+# Local change: the inline clang line shipped here was stale (no Sentry framework,
+# missing frameworks, no C++ lib). The Makefile is the canonical build the GUI
+# patcher uses, so delegate to it.
+make -C "$REPO_DIR" all 2>&1 | tail -5
+[[ -f "$BUILD_DIR/SpliceKit" ]] || { err "Makefile build failed (see output above)"; exit 1; }
 
 log "Built: $(file "$BUILD_DIR/SpliceKit" | grep -o 'universal.*')"
 
@@ -377,7 +376,9 @@ step "Step 4: Injecting dylib into FCP binary"
 BINARY="$MODDED_APP/Contents/MacOS/Final Cut Pro"
 
 # Check if already injected
-if otool -L "$BINARY" 2>/dev/null | grep -q SpliceKit; then
+# Local fix: match the load command itself, not the otool header line, which
+# already contains "SpliceKit" via the ~/Applications/SpliceKit/ install path.
+if otool -L "$BINARY" 2>/dev/null | grep -q '@rpath/SpliceKit.framework/Versions/A/SpliceKit'; then
     log "Already injected (skipping)"
 else
     # Build insert_dylib if needed


### PR DESCRIPTION
## Summary

Building v3.3.9 from a fresh clone fails on a Mac without the Blackmagic RAW SDK, and `patcher/patch_fcp.sh` cannot complete even once the build is fixed. This PR makes the documented terminal path (`./patcher/patch_fcp.sh`) work again on a clean machine.

## Changes

1. **`Sources/SpliceKitBRAW.mm`** — add stubs for `SpliceKit_bootstrapBRAWAtLaunchPhase` and `SpliceKit_handleBRAWAVProbe` in the `#else` (no SDK) branch. Both are called unconditionally from `SpliceKit.m` / `SpliceKitServer.m`, so the Makefile's undefined-`SpliceKit_*` check aborts the link:
   ```
   ERROR: undefined SpliceKit_* symbols in build/SpliceKit:
     _SpliceKit_bootstrapBRAWAtLaunchPhase
     _SpliceKit_handleBRAWAVProbe
   ```
2. **`patcher/patch_fcp.sh`** — build through `make all` instead of the inline `clang` invocation. That line predates the Sentry integration (no `-F patcher/Frameworks -framework Sentry`, no Metal/Vision/C++ flags) and dies on `fatal error: 'Sentry/Sentry.h' file not found`.
3. **`patcher/patch_fcp.sh`** — detect an existing injection by matching the `@rpath/SpliceKit.framework/Versions/A/SpliceKit` load command. The previous `grep -q SpliceKit` also matches otool's header line, which contains the default install path `~/Applications/SpliceKit/`, so injection was always reported as "Already injected (skipping)" on a fresh copy and FCP launched without the dylib.
4. **`patcher/patch_fcp.sh`** — `detect_sign_identity` printed two hashes when an "Apple Development" certificate exists (awk still runs `END` after `exit`), so `codesign` failed with `no identity found` and silently fell back to ad-hoc signing.

The GUI patcher already does 2–4 correctly; this aligns the shell script with it.

## Test plan

- macOS 26.5.2, FCP 12.3 (App Store), Xcode 26 / clang 21, Apple Development identity, no BRAW SDK.
- `bash Scripts/ensure_sentry_framework.sh && ./patcher/patch_fcp.sh` completes: build, framework install, `LC_LOAD_DYLIB` injected (verified with `otool -L`), signature valid with the developer identity, entitlements applied.
- Patched FCP launches, bridge answers `system.version` (`splicekit_version 3.3.9`), `fcpxml.import`, `project.open`, `viewer.capture` and title tools work from the MCP server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the from-source build on machines without the Blackmagic RAW SDK and repairs `patcher/patch_fcp.sh` so the documented terminal path works on a clean machine.

**Bug Fixes**
- Adds stubs for `SpliceKit_bootstrapBRAWAtLaunchPhase` and `SpliceKit_handleBRAWAVProbe` in the no-SDK branch of `Sources/SpliceKitBRAW.mm` to satisfy the Makefile's undefined-symbol check.
- Replaces the stale inline `clang` invocation with `make all`, which includes the Sentry, Metal, Vision, and C++ flags the build needs.
- Matches the `@rpath/SpliceKit.framework/Versions/A/SpliceKit` load command when checking for an existing injection, since `grep SpliceKit` matched the otool header line and always reported "Already injected".
- Fixes `detect_sign_identity` printing two identities by exiting before the `END` block runs, so `codesign` no longer fails and falls back to ad-hoc signing.
- The GUI patcher already handled these cases; this aligns the shell script with it.

<sup>Written for commit 72ec1c1182cc1e76bed93ac41a7d99fd6c6fe27d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/elliotttate/SpliceKit/pull/87?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

